### PR TITLE
fixes for getblocktemplate issues

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -66,7 +66,7 @@ public:
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
-    int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+    int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast() + BLOCK_LIMITER_TIME + 1, GetAdjustedTime());
 
     if (nOldTime < nNewTime)
         pblock->nTime = nNewTime;
@@ -185,7 +185,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bo
         coinbaseTx.vout[0].nValue = 0;
         *pStakeReward = nFees + GetProofOfStakeReward(nHeight, chainparams.GetConsensus());
     } else {
-        
+
         coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
         coinbaseTx.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -209,7 +209,7 @@ UniValue generatetoaddress(const UniValue& params, bool fHelp)
     CBitcoinAddress address(params[1].get_str());
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address");
-    
+
     boost::shared_ptr<CReserveScript> coinbaseScript(new CReserveScript());
     coinbaseScript->reserveScript = GetScriptForDestination(address.Get());
 
@@ -693,7 +693,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             pblocktemplate = NULL;
         }
         CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(scriptDummy, fSupportsSegwit);
+        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(scriptDummy, false, NULL, fSupportsSegwit);
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 


### PR DESCRIPTION
as the commits suggest:

setting segwit in rules results in a out of memory error due to incorrect parameters supplied to BlockAssembler::CreateNewBlock

and

the time encoded into the block provided by getblocktemplate can be rejected by the consensus rules (blocklimiter-time). This ensures the timestamp used is always greater than GetMedianTimePast() + BLOCK_LIMITER_TIME